### PR TITLE
Issue 254 - Allow default dragover event

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -464,9 +464,9 @@
 				isOwner = (activeGroup === group),
 				canSort = options.sort;
 
-			if (evt.preventDefault !== void 0) {
+			if (evt.preventDefault !== void 0 && !options.dragoverBubble) {
 				evt.preventDefault();
-				!options.dragoverBubble && evt.stopPropagation();
+				evt.stopPropagation();
 			}
 
 			if (!_silent && activeGroup &&


### PR DESCRIPTION
Allow default dragover event behaviour to enable dragging text from other browser windows directly into sortable INPUT fields.  I'll create JS Bins to show the existing and proposed behaviour.